### PR TITLE
angular bootstrap v0.14.3 fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "karma-jasmine": "^0.3.6"
   },
   "scripts": {
-    "test": "./node_modules/.bin/karma start --single-run --browsers Chrome tests/karma.conf.js"
+    "test": "./node_modules/.bin/karma start --single-run --browsers Firefox tests/karma.conf.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "tests"
   },
   "dependencies": {
-    "angular-bootstrap": "^0.12.0",
+    "angular-ui-bootstrap": "^0.14.3",
     "angular": "^1.4.3"
   },
   "devDependencies": {
@@ -19,7 +19,7 @@
     "karma-jasmine": "^0.3.6"
   },
   "scripts": {
-    "test": "./node_modules/.bin/karma start --single-run --browsers Firefox tests/karma.conf.js"
+    "test": "./node_modules/.bin/karma start --single-run --browsers Chrome tests/karma.conf.js"
   },
   "repository": {
     "type": "git",

--- a/popover-toggle.js
+++ b/popover-toggle.js
@@ -21,13 +21,17 @@
 
         function link($scope, $element, $attrs) {
             $attrs.popoverTrigger = POPOVER_SHOW;
+            
+            var event;
 
             $scope.$watch($attrs.popoverToggle, function(newValue) {
                 $timeout(function(){
                     if(newValue) {
-                        $element.triggerHandler(POPOVER_SHOW);
+                        event=new Event(POPOVER_SHOW);
+                        $element[0].dispatchEvent(event);
                     } else {
-                        $element.triggerHandler(POPOVER_HIDE);
+                        event=new Event(POPOVER_HIDE);
+                        $element[0].dispatchEvent(event);
                     }
                 });
             })

--- a/tests/karma.conf.js
+++ b/tests/karma.conf.js
@@ -4,8 +4,8 @@ module.exports = function(config) {
 
         files: [
             'node_modules/angular/angular.js',
-            'node_modules/angular-bootstrap/dist/ui-bootstrap.js',
-            'node_modules/angular-bootstrap/dist/ui-bootstrap-tpls.js',
+            'node_modules/angular-ui-bootstrap/ui-bootstrap.js',
+            'node_modules/angular-ui-bootstrap/ui-bootstrap-tpls.js',
             'node_modules/angular-mocks/angular-mocks.js',
             'popover-toggle.js',
             'tests/suite/*.js'


### PR DESCRIPTION
Fix to work popover-toggle with angular-ui-bootstrap v0.14.3. In v0.14.3, angular-bootstrap has switched from jquery events to native JS event. So I have used native dispatchEvent instead of jquery based triggerHandler.
